### PR TITLE
Add form status

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,49 @@
+# 0.7.0
+
+## Features
+* Form `status` is added.
+
+```reason
+type t('field, 'message) =
+  | Editing
+  | Submitting
+  | Submitted
+  | SubmissionFailed(list(('field, 'message)), option('message));
+```
+
+You can access this type via `Formality.FormStatus` module.
+
+Current `status` is exposed via `form` argument of the `children` function. `form.submitting` is kept for convenience.
+
+* **[ BREAKING ]** `onSubmit` handler is changed.
+
+Submission callbacks:
+
+```diff
+- type notifiers = {
+-   onSuccess: unit => unit,
+-   onFailure: unit => unit,
+- };
+
++ type submissionCallbacks('field, 'state, 'message) = {
++   notifyOnSuccess: option('state) => unit,
++   notifyOnFailure: (list(('field, 'message)), option('message)) => unit,
++   reset: unit => unit,
++ };
+```
+
+`onSubmit` prop:
+
+```diff
+- onSubmit=((state, {onSuccess, onFailure}) => ...)
++ onSubmit=((state, {notifyOnSuccess, notifyOnFailure, reset}) => ...)
+```
+
+Previously, if `onSuccess` was called, form was reset. Now, each callback sets appropriate form `status`, or you can explicitly `reset` a form. Also with this change, you can store errors returned from a server in form status `SubmissionFailed(list(('field, 'message)), option('message))` and render them in UI.
+
+## Chore
+* `bs-platform` is updated to `2.2.3`.
+
 # 0.6.0
 
 ## Chore
@@ -5,7 +51,7 @@
 
 # 0.5.0
 
-## Improvements
+## Features
 * **[ BREAKING ]** `value` is user-defined type (was `string`).
 
 In form config:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ let make = (_) => {
   render: (_) =>
     <FormContainer
       initialState={email: "", password: ""}
-      onSubmit=((state, notify) => {
-        /* Submit form and either notify.onSuccess / notify.onFailure */
+      onSubmit=((state, {notifyOnSuccess, notifyOnFailure, reset}) => {
+        /* Submit form and either notifyOnSuccess / notifyOnFailure / reset */
       })
     >
       ...(

--- a/examples/LoginForm.re
+++ b/examples/LoginForm.re
@@ -71,14 +71,16 @@ let make = (_) => {
     <LoginFormContainer
       initialState={email: "", password: ""}
       onSubmit=(
-        (state, notify) => {
+        (state, form) => {
           Js.log2("Called with:", state);
-          Js.log2(
-            "If api returned error this callback should be called:",
-            notify.onFailure,
-          );
-          let _ = Js.Global.setTimeout(notify.onSuccess, 500);
-          ();
+          Js.Global.setTimeout(
+            () => {
+              form.notifyOnSuccess(None);
+              Js.Global.setTimeout(form.reset, 3000) |> ignore;
+            },
+            500,
+          )
+          |> ignore;
         }
       )>
       ...(
@@ -170,6 +172,15 @@ let make = (_) => {
                        |> ReasonReact.stringToElement
                      )
                    </button>
+                   (
+                     switch (form.status) {
+                     | Formality.FormStatus.Submitted =>
+                       <div className=(Cn.make(["form-status", "success"]))>
+                         ({j|✓ Logged In|j} |> ReasonReact.stringToElement)
+                       </div>
+                     | _ => ReasonReact.nullElement
+                     }
+                   )
                  </div>
                </div>
              </form>

--- a/examples/SignupForm.re
+++ b/examples/SignupForm.re
@@ -113,14 +113,16 @@ let make = (_) => {
     <SignupFormContainer
       initialState={email: "", password: "", passwordConfirmation: ""}
       onSubmit=(
-        (state, notify) => {
+        (state, form) => {
           Js.log2("Called with:", state);
-          Js.log2(
-            "If api returned error this callback should be called:",
-            notify.onFailure,
-          );
-          let _ = Js.Global.setTimeout(notify.onSuccess, 500);
-          ();
+          Js.Global.setTimeout(
+            () => {
+              form.notifyOnSuccess(None);
+              Js.Global.setTimeout(form.reset, 3000) |> ignore;
+            },
+            500,
+          )
+          |> ignore;
         }
       )>
       ...(
@@ -264,6 +266,15 @@ let make = (_) => {
                        |> ReasonReact.stringToElement
                      )
                    </button>
+                   (
+                     switch (form.status) {
+                     | Formality.FormStatus.Submitted =>
+                       <div className=(Cn.make(["form-status", "success"]))>
+                         ({j|✓ Signed Up|j} |> ReasonReact.stringToElement)
+                       </div>
+                     | _ => ReasonReact.nullElement
+                     }
+                   )
                  </div>
                </div>
              </form>

--- a/examples/index.css
+++ b/examples/index.css
@@ -189,19 +189,25 @@ button:disabled {
   color: #777;
 }
 
-.form-message {
-  margin-left: 40px;
+.form-message,
+.form-status {
   font-size: 14px;
 }
 
-.form-message.success {
+.form-message {
+  margin-left: 40px;
+}
+
+.form-status {
+  margin-left: 20px;
+}
+
+.form-message.success,
+.form-status.success {
   color: green;
 }
 
-.form-message.weak {
-  color: #b3a709;
-}
-
-.form-message.failure {
+.form-message.failure,
+.form-status.failure {
   color: red;
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "reason-react": "^0.3.0"
   },
   "devDependencies": {
-    "bs-platform": "2.2.2",
-    "re-classnames": "0.0.3",
+    "bs-platform": "2.2.3",
+    "re-classnames": "1.0.0",
     "reason-react": "0.3.4",
     "webpack": "3.11.0"
   }

--- a/src/Formality.re
+++ b/src/Formality.re
@@ -4,6 +4,8 @@ include Formality__PublicHelpers;
 
 module Strategy = Formality__Strategy;
 
+module FormStatus = Formality__FormStatus;
+
 module Make = Formality__Form.Make;
 
 module MakeWithAsyncValidationsOnChange = Formality__FormAsyncOnChange.Make;

--- a/src/Formality__FormAsyncOnBlur.re
+++ b/src/Formality__FormAsyncOnBlur.re
@@ -2,6 +2,8 @@ module Validation = Formality__Validation;
 
 module Strategy = Formality__Strategy;
 
+module FormStatus = Formality__FormStatus;
+
 module Utils = Formality__Utils;
 
 module type Config = {
@@ -66,9 +68,9 @@ module Make = (Form: Config) => {
   };
   type state = {
     data: Form.state,
+    status: FormStatus.t(Form.field, Form.message),
     results: ResultsMap.t,
     validating: FieldsSet.t,
-    submitting: bool,
     submittedOnce: bool,
     emittedFields: FieldsSet.t,
   };
@@ -86,10 +88,15 @@ module Make = (Form: Config) => {
         Validation.validationResult(Form.message),
       )
     | Submit
-    | Reset
-    | HandleSubmissionError;
+    | SetSubmittedStatus(option(Form.state))
+    | SetSubmissionFailedStatus(
+        list((Form.field, Form.message)),
+        option(Form.message),
+      )
+    | Reset;
   type interface = {
     state: Form.state,
+    status: FormStatus.t(Form.field, Form.message),
     results: Form.field => option(Validation.validationResult(Form.message)),
     validating: Form.field => bool,
     submitting: bool,
@@ -99,9 +106,9 @@ module Make = (Form: Config) => {
   };
   let getInitialState = data => {
     data,
+    status: FormStatus.Editing,
     results: ResultsMap.empty,
     validating: FieldsSet.empty,
-    submitting: false,
     submittedOnce: false,
     emittedFields: FieldsSet.empty,
   };
@@ -138,7 +145,16 @@ module Make = (Form: Config) => {
   let make =
       (
         ~initialState: Form.state,
-        ~onSubmit: (Form.state, Validation.notifiers) => unit,
+        ~onSubmit:
+           (
+             Form.state,
+             Validation.submissionCallbacks(
+               Form.field,
+               Form.state,
+               Form.message,
+             )
+           ) =>
+           unit,
         children,
       ) => {
     ...component,
@@ -492,9 +508,9 @@ module Make = (Form: Config) => {
           }) :
           ReasonReact.NoUpdate
       | Submit =>
-        switch (state.validating |> FieldsSet.isEmpty, state.submitting) {
+        switch (state.validating |> FieldsSet.isEmpty, state.status) {
         | (false, _)
-        | (_, true) => ReasonReact.NoUpdate
+        | (_, FormStatus.Submitting) => ReasonReact.NoUpdate
         | _ =>
           let (valid, results) =
             (true, state.results)
@@ -535,14 +551,26 @@ module Make = (Form: Config) => {
                );
           valid ?
             ReasonReact.UpdateWithSideEffects(
-              {...state, results, submitting: true, submittedOnce: true},
+              {
+                ...state,
+                results,
+                status: FormStatus.Submitting,
+                submittedOnce: true,
+              },
               (
                 ({state, send}) =>
                   onSubmit(
                     state.data,
                     {
-                      onSuccess: () => Reset |> send,
-                      onFailure: () => HandleSubmissionError |> send,
+                      notifyOnSuccess: data =>
+                        SetSubmittedStatus(data) |> send,
+                      notifyOnFailure: (fieldLevelErrors, serverMessage) =>
+                        SetSubmissionFailedStatus(
+                          fieldLevelErrors,
+                          serverMessage,
+                        )
+                        |> send,
+                      reset: () => Reset |> send,
                     },
                   )
               ),
@@ -550,20 +578,31 @@ module Make = (Form: Config) => {
             ReasonReact.Update({
               ...state,
               results,
-              submitting: false,
+              status: FormStatus.Editing,
               submittedOnce: true,
             });
         }
+      | SetSubmittedStatus(data) =>
+        switch (data) {
+        | Some(data) =>
+          ReasonReact.Update({...state, data, status: FormStatus.Submitted})
+        | None => ReasonReact.Update({...state, status: FormStatus.Submitted})
+        }
+      | SetSubmissionFailedStatus(fieldLevelErrors, serverMessage) =>
+        ReasonReact.Update({
+          ...state,
+          status:
+            FormStatus.SubmissionFailed(fieldLevelErrors, serverMessage),
+        })
       | Reset => ReasonReact.Update(initialState |> getInitialState)
-      | HandleSubmissionError =>
-        ReasonReact.Update({...state, submitting: false})
       },
     render: ({state, send}) =>
       children({
         state: state.data,
+        status: state.status,
         results: field => state.results |> ResultsMap.get(field),
         validating: field => state.validating |> FieldsSet.mem(field),
-        submitting: state.submitting,
+        submitting: state.status === FormStatus.Submitting,
         change: (field, value) => Change((field, value)) |> send,
         blur: (field, value) => Blur((field, value)) |> send,
         submit: (_) => Submit |> send,

--- a/src/Formality__FormStatus.re
+++ b/src/Formality__FormStatus.re
@@ -1,0 +1,5 @@
+type t('field, 'message) =
+  | Editing
+  | Submitting
+  | Submitted
+  | SubmissionFailed(list(('field, 'message)), option('message));

--- a/src/Formality__Validation.re
+++ b/src/Formality__Validation.re
@@ -21,6 +21,12 @@ type asyncValidator('field, 'value, 'state, 'message) = {
   validateAsync: option(validateAsync('value, 'message)),
 };
 
+type submissionCallbacks('field, 'state, 'message) = {
+  notifyOnSuccess: option('state) => unit,
+  notifyOnFailure: (list(('field, 'message)), option('message)) => unit,
+  reset: unit => unit,
+};
+
 module type ValidatorsConfig = {type t;};
 
 module MakeValidators = (Config: ValidatorsConfig) =>
@@ -30,11 +36,6 @@ module MakeValidators = (Config: ValidatorsConfig) =>
       let compare = Formality__Utils.comparator;
     },
   );
-
-type notifiers = {
-  onSuccess: unit => unit,
-  onFailure: unit => unit /* TODO: notifiers.onFailure should accept errors */
-};
 
 let ifResult = (~valid, ~invalid, result) =>
   switch (result) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,9 +248,9 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-bs-platform@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.2.tgz#95ff37719771bbf310e8376fedd1148865c0da19"
+bs-platform@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -1564,9 +1564,9 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-re-classnames@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/re-classnames/-/re-classnames-0.0.3.tgz#991511e847a3d9ce38bddeadc28f74e2b0333979"
+re-classnames@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/re-classnames/-/re-classnames-1.0.0.tgz#5bb1f068ccb066e932cb79944437b8ba8372a028"
 
 "react-dom@>=15.0.0 || >=16.0.0":
   version "16.2.0"


### PR DESCRIPTION
@kgoggin @rauanmayemir @tmepple I added form `status` and updated submission callbacks: now it's possible to store remote errors in form state, not resetting form on success by default etc.

I'll take a look on changes one more time tomorrow morning, then release `0.7.0`.

Appreciate review!

P.S. Updated examples are deployed BTW: https://formality.now.sh