### PR TITLE
Use pervasives compare and allow to override

### DIFF
--- a/examples/LoginForm.re
+++ b/examples/LoginForm.re
@@ -19,10 +19,12 @@ module LoginForm = {
     | (Password, value) => {...state, password: value}
     };
   let valueEmpty = Formality.emptyString;
+  let comparator = Pervasives.compare;
   module Validators =
     Formality.MakeValidators(
       {
         type t = field;
+        let comparator = Pervasives.compare;
       },
     );
   type validators =

--- a/examples/SignupForm.re
+++ b/examples/SignupForm.re
@@ -26,11 +26,13 @@ module SignupForm = {
       }
     };
   let valueEmpty = Formality.emptyString;
+  let comparator = Pervasives.compare;
   let debounceInterval = Formality.debounceInterval;
   module Validators =
     Formality.MakeValidators(
       {
         type t = field;
+        let comparator = Pervasives.compare;
       },
     );
   type validators =

--- a/src/Formality__Form.re
+++ b/src/Formality__Form.re
@@ -14,6 +14,7 @@ module type Config = {
   let get: (field, state) => value;
   let update: ((field, value), state) => state;
   let valueEmpty: value => bool;
+  let comparator: (field, field) => int;
   type validators;
   let validators: validators;
   module Validators: {
@@ -35,7 +36,7 @@ module Make = (Form: Config) => {
     Set.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module FieldsSet = {
@@ -49,7 +50,7 @@ module Make = (Form: Config) => {
     Map.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module ResultsMap = {

--- a/src/Formality__FormAsyncOnBlur.re
+++ b/src/Formality__FormAsyncOnBlur.re
@@ -14,6 +14,7 @@ module type Config = {
   let get: (field, state) => value;
   let update: ((field, value), state) => state;
   let valueEmpty: value => bool;
+  let comparator: (field, field) => int;
   type validators;
   let validators: validators;
   module Validators: {
@@ -36,7 +37,7 @@ module Make = (Form: Config) => {
     Set.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module FieldsSet = {
@@ -51,7 +52,7 @@ module Make = (Form: Config) => {
     Map.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module ResultsMap = {

--- a/src/Formality__FormAsyncOnChange.re
+++ b/src/Formality__FormAsyncOnChange.re
@@ -16,6 +16,7 @@ module type Config = {
   let get: (field, state) => value;
   let update: ((field, value), state) => state;
   let valueEmpty: value => bool;
+  let comparator: (field, field) => int;
   type validators;
   let validators: validators;
   let debounceInterval: int;
@@ -40,7 +41,7 @@ module Make = (Form: Config) => {
     Set.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module FieldsSet = {
@@ -55,7 +56,7 @@ module Make = (Form: Config) => {
     Map.Make(
       {
         type t = Form.field;
-        let compare = Utils.comparator;
+        let compare = Form.comparator;
       },
     );
   module ResultsMap = {

--- a/src/Formality__Utils.re
+++ b/src/Formality__Utils.re
@@ -1,1 +1,1 @@
-let comparator = (a, b) => a === b ? 0 : 1;
+let comparator = compare;

--- a/src/Formality__Utils.re
+++ b/src/Formality__Utils.re
@@ -1,1 +1,0 @@
-let comparator = compare;

--- a/src/Formality__Validation.re
+++ b/src/Formality__Validation.re
@@ -27,13 +27,13 @@ type submissionCallbacks('field, 'state, 'message) = {
   reset: unit => unit,
 };
 
-module type ValidatorsConfig = {type t;};
+module type ValidatorsConfig = {type t; let comparator: (t, t) => int;};
 
 module MakeValidators = (Config: ValidatorsConfig) =>
   Map.Make(
     {
       type t = Config.t;
-      let compare = Formality__Utils.comparator;
+      let compare = Config.comparator;
     },
   );
 


### PR DESCRIPTION
According to this snippet: 

```ml
type myType =
  | V0
  | V1
  | V2
  | V3;

module MyOrdedType = {
  type t = myType;
  /* works */
  /*  let compare = Pervasives.compare; */
  /* won't works */
  let compare = (a, b) => a === b ? 0 : 1;
};

module MyMap = Map.Make(MyOrdedType);

let map =
  MyMap.(
    empty
    |> add(V0, "This is V0")
    |> add(V1, "This is V1")
    |> add(V2, "This is V2")
    |> add(V3, "This is V3")
  );

switch (map |> MyMap.find(V0)) {
| s => Js.log2("found!", s)
| exception Not_found => Js.log("not found...")
};

```
([live version](https://reasonml.github.io/en/try.html?rrjsx=false&reason=C4TwDgpgBAtiAq5oF4BQUoB8oDUAM6WuAjIdjgExm4DMA3KqjAPYAmArgDbQCyIA8gCdWEVokhRkUAN6FQE4JNgIkDDAHoAVFADuzQQGsAzlE3rCWjN0UBjZjDABDQSigAFCIIBujowEsvCCMAOjsHZwg6U3MNbT0AOwByRT1DEzNCaygwpxclAApHABooACMASkkAPihHSWQpUqgAfig8KAAuKGIGAF8GJjYuXhAeRzAlMbBgsYMIfL4hETEkcoGsmHHJQj4p4PzCDAgHUEOsGsdWVnz8EoAieAALPxMX3Dw78rPMC6ub4nuTzebxwxE+31+10ogOerxMlHBGAwP1qfxwNBhwPhNERUDWjCMOj8wBsjyg+U2ExRu3GwQAZn54lC8OVKrJsCZkDUAFIhTjMADmFHydzpzHYTIAhHcSkYvtgIAAPGwQMDAPzMeJQAByzGAAH0xRLWNUoLzgvyBSL4nqoEamcFHeD+qggA))

Hence I propose a breaking change allow user to provide `comparator` instead of built-in.

