### PR TITLE
Add Reset to initial state to forms

### DIFF
--- a/src/Formality__Form.re
+++ b/src/Formality__Form.re
@@ -57,6 +57,7 @@ module Make = (Form: Form) => {
     blur: Form.field => unit,
     submit: unit => unit,
     dismissSubmissionResult: unit => unit,
+    reset: unit => unit,
   };
 
   let getInitialState = input => {
@@ -334,6 +335,7 @@ module Make = (Form: Form) => {
         blur: field => Blur(field)->send,
         submit: () => Submit->send,
         dismissSubmissionResult: () => DismissSubmissionResult->send,
+        reset: () => Reset->send,
       }),
   };
 };

--- a/src/Formality__FormAsyncOnBlur.re
+++ b/src/Formality__FormAsyncOnBlur.re
@@ -71,6 +71,7 @@ module Make = (Form: Form) => {
     blur: Form.field => unit,
     submit: unit => unit,
     dismissSubmissionResult: unit => unit,
+    reset: unit => unit,
   };
 
   let getInitialState = input => {
@@ -449,6 +450,7 @@ module Make = (Form: Form) => {
         blur: field => Blur(field)->send,
         submit: () => Submit->send,
         dismissSubmissionResult: () => DismissSubmissionResult->send,
+        reset: () => Reset->send,
       }),
   };
 };

--- a/src/Formality__FormAsyncOnChange.re
+++ b/src/Formality__FormAsyncOnChange.re
@@ -99,6 +99,7 @@ module Make = (Form: Form) => {
     blur: Form.field => unit,
     submit: unit => unit,
     dismissSubmissionResult: unit => unit,
+    reset: unit => unit,
   };
 
   let debounce = (~wait, fn) => {
@@ -523,6 +524,7 @@ module Make = (Form: Form) => {
         blur: field => Blur(field)->send,
         submit: () => Submit->send,
         dismissSubmissionResult: () => DismissSubmissionResult->send,
+        reset: () => Reset->send,
       }),
   };
 };


### PR DESCRIPTION
We have a use case at work where we need to be able to Reset the form to it's initial state without submitting it (by pressing a cancel button).

This PR adds that functionality 👍 