### PR TITLE
notifyOnSuccess should make the form un-dirty

### DIFF
--- a/src/Formality__Form.re
+++ b/src/Formality__Form.re
@@ -264,7 +264,12 @@ module Make = (Form: Form) => {
       | SetSubmittedStatus(data) =>
         switch (data) {
         | Some(data) =>
-          React.Update({...state, input: data, status: FormStatus.Submitted})
+          React.Update({
+            ...state,
+            input: data,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Pristine),
+          });
         | None => React.Update({...state, status: FormStatus.Submitted})
         }
 

--- a/src/Formality__Form.re
+++ b/src/Formality__Form.re
@@ -269,8 +269,13 @@ module Make = (Form: Form) => {
             input: data,
             status: FormStatus.Submitted,
             fields: state.fields->Map.map(_ => Validation.Pristine),
-          });
-        | None => React.Update({...state, status: FormStatus.Submitted})
+          })
+        | None =>
+          React.Update({
+            ...state,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Pristine),
+          })
         }
 
       | SetSubmissionFailedStatus(fieldLevelErrors, serverMessage) =>

--- a/src/Formality__FormAsyncOnBlur.re
+++ b/src/Formality__FormAsyncOnBlur.re
@@ -384,8 +384,18 @@ module Make = (Form: Form) => {
       | SetSubmittedStatus(data) =>
         switch (data) {
         | Some(data) =>
-          React.Update({...state, input: data, status: FormStatus.Submitted})
-        | None => React.Update({...state, status: FormStatus.Submitted})
+          React.Update({
+            ...state,
+            input: data,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Async.Pristine),
+          })
+        | None =>
+          React.Update({
+            ...state,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Async.Pristine),
+          })
         }
 
       | SetSubmissionFailedStatus(fieldLevelErrors, serverMessage) =>

--- a/src/Formality__FormAsyncOnChange.re
+++ b/src/Formality__FormAsyncOnChange.re
@@ -446,8 +446,18 @@ module Make = (Form: Form) => {
       | SetSubmittedStatus(data) =>
         switch (data) {
         | Some(data) =>
-          React.Update({...state, input: data, status: FormStatus.Submitted})
-        | None => React.Update({...state, status: FormStatus.Submitted})
+          React.Update({
+            ...state,
+            input: data,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Async.Pristine),
+          })
+        | None =>
+          React.Update({
+            ...state,
+            status: FormStatus.Submitted,
+            fields: state.fields->Map.map(_ => Validation.Async.Pristine),
+          })
         }
 
       | SetSubmissionFailedStatus(fieldLevelErrors, serverMessage) =>


### PR DESCRIPTION
We have a use case at work where we need the form to not be dirty after using notifyOnSuccess so the save button on our form is disabled until the user edits some field again after submitting.

This PR adds that functionality 😁